### PR TITLE
security(webui): declare the CSP in the page, not only in config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,6 @@
 - Fixed Build.TIME and Build.VERSION.SDK_INT_FULL getting garbage when the config has no TIMESTAMP, SDK_FULL or SDK_INT.
 - The WebUI no longer loads anything from the internet: marked, the fonts, the readme and the license are inside the module.
 - The WebUI no longer builds shell commands out of file names. A crafted file name on shared storage could run commands as root through the file picker.
-- The WebUI content security policy went from default-src * to default-src 'none'.
+- The WebUI content security policy went from default-src * to default-src 'none', declared both in config.json and in the page itself, so it also applies under KsuWebUIStandalone (Magisk), which does not read config.json.
 
 _The new build only reaches android.os.Build after a reboot: resetprop is re-applied right away, but zygisk reads the config when zygote starts._

--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -6,7 +6,11 @@
     <meta name="theme-color" content="#60A5FA" id="theme-color">
     <title>COPG-VD</title>
     <!-- Everything is served from inside the module. This page can run root commands
-         through ksu.exec, so it must never load code or content off the network. -->
+         through ksu.exec, so it must never load code or content off the network.
+         The same policy lives in webroot/config.json, which only KernelSU's own WebUI
+         reads - KsuWebUIStandalone (what Magisk users run) ignores it and just serves
+         this directory, so without the meta tag those users would get no policy at all. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; form-action 'none'; base-uri 'none'">
     <link rel="stylesheet" href="fonts.css">
     <link rel="stylesheet" href="styles.css">
     <script src="marked.min.js"></script>


### PR DESCRIPTION
KsuWebUIStandalone (what Magisk users run) never reads `webroot/config.json` - it serves the directory through `WebViewAssetLoader` and loads `index.html`. The policy tightened in config.json therefore applied to KernelSU's own WebUI and to nobody else.

The meta tag carries the same policy to every host. Safe here: no inline script, no inline handler, no data: URI, no external resource, and the `ksu` bridge is an `addJavascriptInterface` with `evaluateJavascript` callbacks - neither is subject to `script-src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)