### PR TITLE
fix: awk on Android refuses a newline inside -v, and it was silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  . "spoof_version": "force" is refused from the config and downgraded to "rom" - restoring an old backup must not re-arm the dangerous mode behind your back. Arm it in the WebUI.
 - "Spoof ro.product.manufacturer" no longer edits service.sh, so it survives module updates. If you had it off, set it again after updating.
 - Fixed the prop reader taking several lines at once when the config holds more than one object.
+- Fixed updates failing on the device while passing on a PC: the field list was written across two lines, and Android's awk refuses a newline inside a -v assignment. Half the fields were never refreshed, silently.
 
 _The version group only reaches apps after a reboot. If you came from v5.0.x and the phone kept rebooting on its own, this is the update that stops it._
 

--- a/module/fingerprint-update.sh
+++ b/module/fingerprint-update.sh
@@ -45,9 +45,10 @@ ROM_PROP="/system/build.prop"
 VERSION_FIELDS="ANDROID_VERSION SDK_INT SDK_FULL CODENAME"
 SETTINGS_OBJECT="COPG-VD-Settings"
 # Keys the module actually understands - anything else in the object does nothing.
-KNOWN_KEYS="BRAND DEVICE MANUFACTURER MODEL FINGERPRINT PRODUCT BOOTLOADER BOARD HARDWARE
-            DISPLAY ID HOST INCREMENTAL TIMESTAMP PREVIEW_SDK USER SDK_FINGERPRINT UUID
-            SECURITY_PATCH ANDROID_VERSION SDK_INT SDK_FULL CODENAME TAGS TYPE ODM_SKU SKU"
+# One line, deliberately: Android's awk refuses a newline inside a -v assignment ("newline in
+# string ... at source line 1") and the whole program dies. Fedora's gawk accepts it, so this
+# only ever breaks on the device - which is exactly where it matters.
+KNOWN_KEYS="BRAND DEVICE MANUFACTURER MODEL FINGERPRINT PRODUCT BOOTLOADER BOARD HARDWARE DISPLAY ID HOST INCREMENTAL TIMESTAMP PREVIEW_SDK USER SDK_FINGERPRINT UUID SECURITY_PATCH ANDROID_VERSION SDK_INT SDK_FULL CODENAME TAGS TYPE ODM_SKU SKU"
 STATE_FILE="/data/adb/$MODULE_ID.update.state"
 LOG_FILE="/data/adb/$MODULE_ID.update.log"
 LOG_MAX=32768
@@ -63,8 +64,9 @@ if [ -z "$AWK" ]; then
 fi
 
 # Refreshed from upstream. Everything else in the file is left alone.
-FIELDS="FINGERPRINT ID DISPLAY INCREMENTAL TIMESTAMP SECURITY_PATCH
-        PREVIEW_SDK SDK_FINGERPRINT UUID HOST USER"
+# Single line for the same reason as KNOWN_KEYS: this one is passed to awk by write_fields,
+# so a newline here meant every update failed on a real device while passing on a PC.
+FIELDS="FINGERPRINT ID DISPLAY INCREMENTAL TIMESTAMP SECURITY_PATCH PREVIEW_SDK SDK_FINGERPRINT UUID HOST USER"
 # Must match upstream, otherwise the user is spoofing something else.
 IDENTITY="BRAND DEVICE MANUFACTURER MODEL PRODUCT"
 # Re-evaluate attestation with the new props. com.android.vending is deliberately left


### PR DESCRIPTION
Found on the device: `newline in string BRAND DEVICE MANUFAC... at source line 1`, and the unknown-keys check silently produced nothing.

The same shape was in `FIELDS`, which `write_fields` passes to awk - so on a real device every update would have died there, leaving the second-line fields (PREVIEW_SDK, SDK_FINGERPRINT, UUID, HOST, USER) unrefreshed. Fedora's gawk accepts it, which is why the sandbox never complained.

Proved on the phone: HOST and UUID blanked by hand came back from upstream after `apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)